### PR TITLE
Fix empty scenarios

### DIFF
--- a/src/main/java/io/github/eroshenkoam/allure/command/ExportTestCasesCommand.java
+++ b/src/main/java/io/github/eroshenkoam/allure/command/ExportTestCasesCommand.java
@@ -105,9 +105,16 @@ public class ExportTestCasesCommand extends AbstractTestOpsCommand {
 
     private List<TestCaseStepDto> getTestCaseSteps(final TestCaseService service,
                                                    final TestCaseDto testCase) throws IOException {
-        final Response<Scenario> scenarioResponse = testCase.isAutomated()
-                ? service.getScenarioFromRun(testCase.getId()).execute()
-                : service.getScenario(testCase.getId()).execute();
+//        final Response<Scenario> scenarioResponse = testCase.isAutomated()
+//                ? service.getScenarioFromRun(testCase.getId()).execute()
+//                : service.getScenario(testCase.getId()).execute();
+        final Response<Scenario> automatedScenario = service.getScenarioFromRun(testCase.getId()).execute();
+        final Response<Scenario> manualScenario = service.getScenario(testCase.getId()).execute();
+        final Response<Scenario>
+                scenarioResponse = automatedScenario.body() != null
+                && automatedScenario.body().getSteps() != null
+                && automatedScenario.body().getSteps().size() != 0
+                ? automatedScenario : manualScenario;
         if (scenarioResponse.isSuccessful()) {
             return convertSteps(scenarioResponse.body().getSteps());
         }

--- a/src/main/java/io/github/eroshenkoam/allure/command/ExportTestCasesCommand.java
+++ b/src/main/java/io/github/eroshenkoam/allure/command/ExportTestCasesCommand.java
@@ -8,11 +8,7 @@ import io.github.eroshenkoam.allure.util.FreemarkerUtil;
 import io.github.eroshenkoam.allure.util.PDFUtil;
 import io.qameta.allure.ee.client.ServiceBuilder;
 import io.qameta.allure.ee.client.TestCaseService;
-import io.qameta.allure.ee.client.dto.Attachment;
-import io.qameta.allure.ee.client.dto.Page;
-import io.qameta.allure.ee.client.dto.Scenario;
-import io.qameta.allure.ee.client.dto.Step;
-import io.qameta.allure.ee.client.dto.TestCase;
+import io.qameta.allure.ee.client.dto.*;
 import okhttp3.ResponseBody;
 import picocli.CommandLine;
 import retrofit2.Response;
@@ -21,11 +17,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
 
 @CommandLine.Command(
         name = "export-testcases", mixinStandardHelpOptions = true,
@@ -110,8 +102,7 @@ public class ExportTestCasesCommand extends AbstractTestOpsCommand {
 //                : service.getScenario(testCase.getId()).execute();
         final Response<Scenario> automatedScenario = service.getScenarioFromRun(testCase.getId()).execute();
         final Response<Scenario> manualScenario = service.getScenario(testCase.getId()).execute();
-        final Response<Scenario>
-                scenarioResponse = automatedScenario.body() != null
+        final Response<Scenario> scenarioResponse = automatedScenario.body() != null
                 && automatedScenario.body().getSteps() != null
                 && automatedScenario.body().getSteps().size() != 0
                 ? automatedScenario : manualScenario;


### PR DESCRIPTION
Пофиксил момент когда сценарии были без шагов, но при этом в TMS были шаги.
Это было из за того, что часть сценариев были isAutomated = false, но при этом шаги можно было вытянуть  отсюда service.getScenarioFromRun(testCase.getId()).execute().
Понимаю, что теперь к апи аллюра будет всегда два запроса, но зато теперь шаги точно не потеряются.