### PR TITLE
Add per-launch cleanup progress logs

### DIFF
--- a/src/main/java/io/github/eroshenkoam/allure/command/LaunchCleanCommand.java
+++ b/src/main/java/io/github/eroshenkoam/allure/command/LaunchCleanCommand.java
@@ -62,9 +62,6 @@ public class LaunchCleanCommand extends AbstractTestOpsCommand {
 
         for (int index = 0; index < launchesToDelete.size(); index++) {
             final Launch launch = launchesToDelete.get(index);
-            final String launchName = Optional.ofNullable(launch.getName()).orElse("<no-name>");
-            System.out.printf("Deleting launch [%s/%s]: id=%s, name=%s%n",
-                    index + 1, launchesToDelete.size(), launch.getId(), launchName);
             executeRequest(service.delete(launch.getId()));
             System.out.printf("Deleted launch [%s/%s]: id=%s%n",
                     index + 1, launchesToDelete.size(), launch.getId());

--- a/src/main/java/io/github/eroshenkoam/allure/command/LaunchCleanCommand.java
+++ b/src/main/java/io/github/eroshenkoam/allure/command/LaunchCleanCommand.java
@@ -60,8 +60,14 @@ public class LaunchCleanCommand extends AbstractTestOpsCommand {
         final List<Launch> launchesToDelete = getLaunches(service, launchQuery.toString());
         System.out.printf("Found [%s] launches by query [%s]\n", launchesToDelete.size(), launchQuery);
 
-        for (Launch launch : launchesToDelete) {
+        for (int index = 0; index < launchesToDelete.size(); index++) {
+            final Launch launch = launchesToDelete.get(index);
+            final String launchName = Optional.ofNullable(launch.getName()).orElse("<no-name>");
+            System.out.printf("Deleting launch [%s/%s]: id=%s, name=%s%n",
+                    index + 1, launchesToDelete.size(), launch.getId(), launchName);
             executeRequest(service.delete(launch.getId()));
+            System.out.printf("Deleted launch [%s/%s]: id=%s%n",
+                    index + 1, launchesToDelete.size(), launch.getId());
         }
     }
 


### PR DESCRIPTION
## What changed
- Added launch deletion logging to `clean-launches` in `LaunchCleanCommand`

## Why
Cleanup can run for a long time. With this change, progress is visible in logs during launch deletion.

## Notes
- Functional behavior is unchanged; only logging was added.